### PR TITLE
Fixed deallocation of user-defined Numpy scalar flux

### DIFF
--- a/src/CPUSolver.cpp
+++ b/src/CPUSolver.cpp
@@ -155,7 +155,7 @@ void CPUSolver::setFluxes(FP_PRECISION* in_fluxes, int num_fluxes) {
 
   /* Set the scalar flux array pointer to the array passed in from NumPy */
   _scalar_flux = in_fluxes;
-  _user_fluxes = false;
+  _user_fluxes = true;
 }
 
 

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -69,7 +69,7 @@ Solver::~Solver() {
   if (_boundary_flux != NULL)
     delete [] _boundary_flux;
 
-  if (_scalar_flux != NULL)
+  if (_scalar_flux != NULL && !_user_fluxes)
     delete [] _scalar_flux;
 
   if (_old_scalar_flux != NULL)

--- a/src/accel/cuda/GPUSolver.cu
+++ b/src/accel/cuda/GPUSolver.cu
@@ -1024,7 +1024,7 @@ void GPUSolver::setFluxes(FP_PRECISION* in_fluxes, int num_fluxes) {
   /* Copy the input fluxes onto the GPU */
   cudaMemcpy((void*)scalar_flux, (void*)in_fluxes,
              num_fluxes * sizeof(FP_PRECISION), cudaMemcpyHostToDevice);  
-  _user_fluxes = false;
+  _user_fluxes = true;
 }
 
 


### PR DESCRIPTION
This PR _should_ resolve the deallocation issue you've observed at the end of an IRAM solve.
